### PR TITLE
Path autoloading

### DIFF
--- a/bin/genpath.bat
+++ b/bin/genpath.bat
@@ -8,14 +8,8 @@ pushd %CD%
 cd /d "%CMDER_ROOT%\bin"
 
 for /d %%D in (*) do (
-    set hasexe=
-    :: Check for existence of folders with executables in \bin
-    if exist "%%D\*.exe" set hasexe=true
-    if exist "%%D\*.bat" set hasexe=true
-    if "!hasexe!" == "true" (
-        set PATH=!PATH!;%CD%\%%D
-    )
-
+    :: Check for existence of folders in bin
+    set PATH=!PATH!;%CD%\%%D
     :: Find all \bin\*\bin and also add them
     if exist "%%D\bin" (
         set PATH=!PATH!;%CD%\%%D\bin

--- a/bin/pathgen.bat
+++ b/bin/pathgen.bat
@@ -1,0 +1,28 @@
+:: This script checks for folders in \bin that contain executables
+:: and adds them to PATH. It also adds all folders that match \bin\*\bin
+
+@echo off
+setlocal EnableDelayedExpansion
+
+pushd %CD%
+cd /d "%CMDER_ROOT%\bin"
+
+for /d %%D in (*) do (
+    set hasexe=
+    :: Check for existence of folders with executables in \bin
+    if exist "%%D\*.exe" set hasexe=true
+    if exist "%%D\*.bat" set hasexe=true
+    if "!hasexe!" == "true" (
+        set PATH=!PATH!;%CD%\%%D
+    )
+
+    :: Find all \bin\*\bin and also add them
+    if exist "%%D\bin" (
+        set PATH=!PATH!;%CD%\%%D\bin
+    )
+)
+
+popd
+endlocal & ( PATH = %PATH%;%CMDER_ROOT%\bin )
+
+


### PR DESCRIPTION
Adds `/bin/*` and `/bin/*/bin` to PATH. So you do not have to fumble around with env variables. This is mainly based on #82.  Should be fixing #61. 

Todo:
- [ ] Actually run it in init.bat