### PR TITLE
Improved experience for displaying git prompt status

### DIFF
--- a/config/git.lua
+++ b/config/git.lua
@@ -1,24 +1,13 @@
----
- -- Find out current branch
- -- @return {false|git branch name}
----
-function get_git_branch()
-    for line in io.popen("git branch 2>nul"):lines() do
-        local m = line:match("%* (.+)$")
+-- Make sure GitPromptClient.exe, GitPromptCache.exe and git2.dll are in the same folder and also part of %path%.
+function get_repo_details()
+    for line in io.popen("GitPromptClient 2>nul"):lines() do
+        local m = line:match("^%(.+")
         if m then
             return m
         end
     end
 
     return false
-end
-
----
- -- Get the status of working dir
- -- @return {bool}
----
-function get_git_status()
-    return os.execute("git diff --quiet --ignore-submodules HEAD")
 end
 
 function git_prompt_filter()
@@ -29,22 +18,35 @@ function git_prompt_filter()
         dirty = "\x1b[31;1m",
     }
 
-    local branch = get_git_branch()
-    if branch then
-        -- Has branch => therefore it is a git folder, now figure out status
-        if get_git_status() then
-            color = colors.clean
-        else
+    local details = get_repo_details()
+
+    if details then
+
+        local branch, addedIndex, deletedIndex, modifiedIndex, addedWorkdir, deletedWorkdir, modifiedWorkdir, repoState  = string.match(details, "%((.*)%) i%[%+(%d+), %-(%d), %~(%d)%] w%[%+(%d+), %-(%d), %~(%d)%] %((.*)%)")
+
+        local added = addedIndex + addedWorkdir
+        local deleted = deletedIndex + deletedWorkdir
+        local modified = modifiedIndex + modifiedWorkdir
+
+        local total = added + deleted + modified
+
+        if total > 0 then
             color = colors.dirty
+        else
+            color = colors.clean
         end
 
-        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")")
+        if repoState ~= "" then
+            -- specifies if any operation(merge/rebase etc..) in progress.. 
+            repoState = " ("..repoState..")"
+        end
+
+        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")"..colors.clean.." [+"..added..", -"..deleted..", ~"..modified.."]"..repoState)
         return true
     end
-
-    -- No git present or not in git file
     clink.prompt.value = string.gsub(clink.prompt.value, "{git}", "")
     return false
 end
 
 clink.prompt.register_filter(git_prompt_filter, 50)
+

--- a/config/git.lua
+++ b/config/git.lua
@@ -22,7 +22,7 @@ function git_prompt_filter()
 
     if details then
 
-        local branch, addedIndex, deletedIndex, modifiedIndex, addedWorkdir, deletedWorkdir, modifiedWorkdir, repoState  = string.match(details, "%((.*)%) i%[%+(%d+), %-(%d), %~(%d)%] w%[%+(%d+), %-(%d), %~(%d)%] %((.*)%)")
+        local branch, addedIndex, deletedIndex, modifiedIndex, addedWorkdir, deletedWorkdir, modifiedWorkdir, repoState  = string.match(details, "%((.*)%) i%[%+(%d+), %-(%d+), %~(%d+)%] w%[%+(%d+), %-(%d+), %~(%d+)%] %((.*)%)")
 
         local added = addedIndex + addedWorkdir
         local deleted = deletedIndex + deletedWorkdir

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -24,7 +24,7 @@
 
 :: Enhance Path
 @set git_install_root=%CMDER_ROOT%\vendor\msysgit
-@set PATH=%CMDER_ROOT%\bin;%git_install_root%\bin;%git_install_root%\mingw\bin;%git_install_root%\cmd;%git_install_root%\share\vim\vim73;%CMDER_ROOT%;%PATH%
+@set PATH=%CMDER_ROOT%\bin;%CMDER_ROOT%\vendor\gitprompt;%git_install_root%\bin;%git_install_root%\mingw\bin;%git_install_root%\cmd;%git_install_root%\share\vim\vim73;%CMDER_ROOT%;%PATH%
 
 :: Add aliases
 @doskey /macrofile="%CMDER_ROOT%\config\aliases"

--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -13,5 +13,11 @@
         "name": "conemu-maximus5",
         "version": "140404",
         "url": "https://conemu.codeplex.com/downloads/get/823971"
+    },
+    {
+        "name": "gitprompt",
+        "version": "v0.1-beta.5",
+        "url": "https://github.com/fieryorc/gitprompt/releases/download/v0.1-beta.5/gitprompt-v0.1-beta.5.zip"
     }
 ]
+


### PR DESCRIPTION
Using cmder when working with large git repositories can be non-ideal experience due the fact running git status takes a while which results in prompt display to be very slow.

This change makes changes to cmder to use gitprompt tool instead of git to display prompt.
gitprompt (https://github.com/fieryorc/gitprompt) provides cached status for git repositories, which has much better experience on larger repos.

Also I have published a release based on this change, if you want to test.
https://github.com/fieryorc/cmder/releases/tag/v1.2-gitprompt.1