### PR TITLE
FIX CMDER_ROOT for admin launch

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -4,7 +4,7 @@
 
 :: Find root dir
 @if not defined CMDER_ROOT (
-    for /f %%i in ("%ConEmuDir%\..\..") do @set CMDER_ROOT=%%~fi
+    for /f "delims=" %%i in ("%ConEmuDir%\..\..") do @set CMDER_ROOT=%%~fi
 )
 
 :: Change the prompt style


### PR DESCRIPTION
When launching a cmd in admin mode, if `%ConEmuDir%\..\..` contains any space, it breaks the init script.
Thanks to this patch, the path is correctly defined now.