### PR TITLE
Border less window mode

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -138,7 +138,7 @@
 			<value name="HideChildCaption" type="hex" data="01"/>
 			<value name="FocusInChildWindows" type="hex" data="01"/>
 			<value name="HideCaptionAlways" type="hex" data="00"/>
-			<value name="HideCaptionAlwaysFrame" type="hex" data="ff"/>
+			<value name="HideCaptionAlwaysFrame" type="hex" data="00"/>
 			<value name="HideCaptionAlwaysDelay" type="dword" data="000007d0"/>
 			<value name="HideCaptionAlwaysDisappear" type="dword" data="000007d0"/>
 			<value name="DownShowHiddenMessage" type="hex" data="00"/>


### PR DESCRIPTION
Disable ugly grey windows borders. Especially beautiful for the Quake mode.

Now for the development branch. Copy of the https://github.com/bliker/cmder/pull/320

And with screenshot of the borderless cmder when quake mode is enabled.
![borderless_cmder](https://cloud.githubusercontent.com/assets/5702278/5112881/ff8bfad0-6fdf-11e4-911a-5380a97f48cb.png)