### PR TITLE
Update clink to latest (0.4.3) version

### DIFF
--- a/vendor/sources.json
+++ b/vendor/sources.json
@@ -6,8 +6,8 @@
     },
     {
         "name": "clink",
-        "version": "0.4.2",
-        "url": "https://github.com/mridgers/clink/releases/download/0.4.2/clink_0.4.2.zip"
+        "version": "0.4.3",
+        "url": "https://github.com/mridgers/clink/releases/download/0.4.3/clink_0.4.3.zip"
     },
     {
         "name": "conemu-maximus5",


### PR DESCRIPTION
Clink 0.4.3 was released recently. This updates clink version in vendor/sources.json