### PR TITLE
Handle quoted paths

### DIFF
--- a/bin/alias.bat
+++ b/bin/alias.bat
@@ -1,13 +1,16 @@
 @echo off
 if ["%1"] == ["/?"] goto:p_help
 if ["%2"] == [""] echo Insufficient parameters. & goto:p_help
-::validate alias
+
 setlocal
-for /f "delims== tokens=1" %%G in ("%*") do set _temp2=%%G
+::handle quotes within command definition, e.g. quoted long file names
+set _x="%*"
+set _x=%_x:"=%
 
-	set _temp=%_temp2: =%
-
-if not ["%_temp%"] == ["%_temp2%"] (
+::validate alias
+for /f "delims== tokens=1" %%G in ("%_x%") do set alias=%%G
+set _temp=%alias: =%
+if not ["%_temp%"] == ["%alias%"] (
 	echo Your alias name can not contain a space
 	endlocal
 	goto:eof


### PR DESCRIPTION
I was annoyed at having to use short paths all the time in my aliases. It wasn't until I found a command that actually refused to work with a shortpath (running iisexpress.exe) I was determined to find a solution. 

It appears that the reason the quoted paths weren't working was due to the ::validate alias stuff. The for command would stumble on a quoted path, arguing that /foo was unexpected...

The additions on lines 7-8 wrap the input in quotes and then strip the inner quotes. This variable is used in the for loop (instead of %*) for validating the alias. So long as the alias is valid (contains no spaces) then the existing method of appending the new alias to the aliases file works just fine because it still uses %*.