### PR TITLE
Use a -Full parameter to download all sources rather than the minimum

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -11,7 +11,11 @@
 .EXAMPLE
     .\build.ps1
 
-    Executes the default build for cmder, this is equivalent to the "minimum" style package in the releases
+    Executes the default build for cmder; Conemu, clink. This is equivalent to the "minimum" style package in the releases
+.EXAMPLE
+    .\build.ps1 -Full
+
+    Executes a full build for cmder, including git. This is equivalent to the "full" style package in the releases
 .EXAMPLE
     .\build -verbose
 
@@ -27,7 +31,6 @@
 .LINK
     https://github.com/bliker/cmder - Project Home
 #>
-
 [CmdletBinding(SupportsShouldProcess=$true)]
 Param(
     # CmdletBinding will give us;
@@ -41,7 +44,10 @@ Param(
     [string]$saveTo = "..\vendor\",
 
     # Launcher folder location
-    [string]$launcher = "..\launcher"
+    [string]$launcher = "..\launcher",
+
+    # Include git with the package build
+    [switch]$Full,
 )
 
 . "$PSScriptRoot\utils.ps1"
@@ -55,6 +61,10 @@ Ensure-Exists $sourcesPath
 Ensure-Executable "7z"
 
 foreach ($s in $sources) {
+    if($Full -eq $false -and $s.name -eq "msysgit"){
+        Continue
+    }
+
     Write-Verbose "Getting $($s.name) from URL $($s.url)"
 
     # We do not care about the extensions/type of archive


### PR DESCRIPTION
Use a full switch to indicate if we want to go and pull a copy of git
since its huge and if a developer is cloning the repo to work on and needs
to build it they already have git.

This isn't the a very robust way to do it but it gets the job done for now. I'm just trying to improve a contributors first experience