### PR TITLE
Added support for gzipped vendor files and some other small improvements.

### DIFF
--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -11,7 +11,7 @@
 
     Creates default archives for cmder
 .EXAMPLE
-    .\build -verbose
+    .\build.ps1 -verbose
 
     Creates default archives for cmder with plenty of information
 .NOTES


### PR DESCRIPTION
I wanted to add another library to my vendor files, specifically github's [hub utility](https://github.com/github/hub/), but all the downloads are gzipped tar.gz files which need to be extracted twice using 7zip.

The code in utils.ps1 will check if the file is gzipped and then extract it twice using temporary files and other things. The code feels a little hacky and is not very well documented. Would be pretty cool if someone could create some cleaner code or find some improvements for mine.

I also added a `-NoDownload` switch which skips all downloads when building. Very useful for debugging the launcher.

I always had problems with the MSBuild.exe file, which one to use, where to place it and some other things, so I added some code that finds the correct one for you and then uses it instead. `[System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory() + "MSBuild.exe"` Finds the path to the file (example: `C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe`) and then executes it with `&$msBuild CmderLauncher.vcxproj...`. I'm honestly not sure exactly what the `&` does, but it makes the code work.

And lastly I fixed up the code style a bit. It's still all over the place but I made it a bit more consistent. I wasn't able to find any real style guides.

Let me know if there's anything you don't like or want changed.