### PR TITLE
Fix build script removing a trailing comma. Download into a temp folder.

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -47,7 +47,7 @@ Param(
     [string]$launcher = "..\launcher",
 
     # Include git with the package build
-    [switch]$Full,
+    [switch]$Full
 )
 
 . "$PSScriptRoot\utils.ps1"
@@ -59,6 +59,7 @@ $sources = Get-Content $sourcesPath | Out-String | Convertfrom-Json
 # Check for requirements
 Ensure-Exists $sourcesPath
 Ensure-Executable "7z"
+New-Item -Type Directory -Path (Join-Path $saveTo "/tmp/") -ErrorAction SilentlyContinue >$null
 
 foreach ($s in $sources) {
     if($Full -eq $false -and $s.name -eq "msysgit"){
@@ -68,7 +69,7 @@ foreach ($s in $sources) {
     Write-Verbose "Getting $($s.name) from URL $($s.url)"
 
     # We do not care about the extensions/type of archive
-    $tempArchive = "$($s.name).tmp"
+    $tempArchive = "tmp/$($s.name).tmp"
     Delete-Existing $tempArchive
     Delete-Existing $s.name
 

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -28,7 +28,7 @@ function Delete-Existing ($path) {
 }
 
 function Extract-Archive ($source, $target) {
-    Invoke-Expression "7z x -y -o$($target) $source  > `$null"
+    Invoke-Expression "7z x -y -o$($target) '$source' > `$null"
     if ($lastexitcode -ne 0) {
         Write-Error "Extracting of $source failied"
     }


### PR DESCRIPTION
I made a bad patch with the parameters syntax. I'm making the temp files
go into a subfolder as if the build script stop theres a .tmp that could
be accidentially tracked by source control.