### PR TITLE
Adds support for PS 4.0 native hash command to remove a dependency

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -54,6 +54,10 @@ function Flatten-Directory ($name) {
 }
 
 function Digest-MD5 ($path) {
+    if(Get-Command Get-FileHash -ErrorAction SilentlyContinue){
+        return (Get-FileHash -Algorithm MD5 -Path $path).Hash
+    }
+
     return Invoke-Expression "md5sum $path"
 }
 


### PR DESCRIPTION
Just doing a bit to remove external dependencies where I can. 

PS 4.0 requires installing WMF 4.0 on windows 7, 8, Server 2012
Native on 8.1, Server 2012r2