### PR TITLE
Leverage the Module Autoload path and save doing it ourselves.

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -1,17 +1,9 @@
-﻿# Global modules directory
-$global:PsGetDestinationModulePath = $PSScriptRoot + "\..\vendor\psmodules"
+﻿# Add Cmder modules directory to the autoload path.
+$CmderModulePath = Join-path $PSScriptRoot "psmodules/"
 
-# Push to modules location
-Push-Location -Path ($PsGetDestinationModulePath)
-
-# Load modules from current directory
-Import-Module .\PsGet\PsGet
-Get-ChildItem -Exclude "PsGet" -Directory -Name | Foreach-Object {
-    Import-Module .\$_\$_
+if( -not $env:PSModulePath.Contains($CmderModulePath) ){
+    $env:PSModulePath = $env:PSModulePath.Insert(0, "$CmderModulePath;")
 }
-
-# Come back to PWD
-Pop-Location
 
 # Set up a Cmder prompt, adding the git prompt parts inside git repos
 function global:prompt {


### PR DESCRIPTION
The seems like the intended way to do this. Only possible problem is our path is first in the load preferences. Perhaps someone could hijack a native module by loading one of the same name first I've never tried. I think PS has something to avoid collisions.  The standard path has the users home `WindowsPowershell\Modules` here before the system one so I don't think it's a problem. 

see `$env:PSModulePath.split(';')` for the curious. I guess that loads top down, or left to right in that order? We're either last or first. 

This should be faster too as we won't automatically import all functions
to the session. Powershell now knows where to look before declaring they
don't exist.