### PR TITLE
Revert new line from commit dc834cc28f

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -17,7 +17,7 @@ Pop-Location
 function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
     $Host.UI.RawUI.ForegroundColor = "White"
-    Write-Host("`n" + $pwd.ProviderPath) -NoNewLine -ForegroundColor Green
+    Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
     if (Get-Module posh-git) {
         Write-VcsStatus
     }


### PR DESCRIPTION
This matches how cmd looks in conemu for cmder and PS seems to add some
padding around command output so I really don't see what the extra new
line is doing.

Saving dat precious vertical space.