### PR TITLE
Improves performance of prompt filtering

### DIFF
--- a/config/cmder.lua
+++ b/config/cmder.lua
@@ -3,6 +3,65 @@ function lambda_prompt_filter()
 end
 
 ---
+ -- Resolves closest directory location for specified directory.
+ -- Navigates subsequently up one level and tries to find specified directory
+ -- @param  {string} path    Path to directory will be checked. If not provided
+ --                          current directory will be used
+ -- @param  {string} dirname Directory name to search for
+ -- @return {string} Path to specified directory or nil if such dir not found
+local function get_dir_contains(path, dirname)
+
+    -- return parent path for specified entry (either file or directory)
+    local function pathname(path)
+        local prefix = ""
+        local i = path:find("[\\/:][^\\/:]*$")
+        if i then
+            prefix = path:sub(1, i-1)
+        end
+        return prefix
+    end
+
+    -- Navigates up one level
+    local function up_one_level(path)
+        if path == nil then path = '.' end
+        if path == '.' then path = clink.get_cwd() end
+        return pathname(path)
+    end
+
+    -- Checks if provided directory contains git directory
+    local function has_specified_dir(path, specified_dir)
+        if path == nil then path = '.' end
+        local found_dirs = clink.find_dirs(path..'/'..specified_dir)
+        if #found_dirs > 0 then return true end
+        return false
+    end
+
+    -- Set default path to current directory
+    if path == nil then path = '.' end
+
+    -- If we're already have .git directory here, then return current path
+    if has_specified_dir(path, dirname) then
+        return path..'/'..dirname
+    else
+        -- Otherwise go up one level and make a recursive call
+        local parent_path = up_one_level(path)
+        if parent_path == path then
+            return nil
+        else
+            return get_dir_contains(parent_path, dirname)
+        end
+    end
+end
+
+local function get_hg_dir(path)
+    return get_dir_contains(path, '.hg')
+end
+
+local function get_git_dir(path)
+    return get_dir_contains(path, '.git')
+end
+
+---
  -- Find out current branch
  -- @return {false|mercurial branch name}
 ---
@@ -36,18 +95,20 @@ function hg_prompt_filter()
         dirty = "\x1b[31;1m",
     }
 
-    local branch = get_hg_branch()
-    if branch then
-        -- Has branch => therefore it is a mercurial folder, now figure out status
-        if get_hg_status() then
-            color = colors.clean
-        else
-            color = colors.dirty
-        end
+    if get_hg_dir() then
+        -- if we're inside of mercurial repo then try to detect current branch
+        local branch = get_hg_branch()
+        if branch then
+            -- Has branch => therefore it is a mercurial folder, now figure out status
+            if get_hg_status() then
+                color = colors.clean
+            else
+                color = colors.dirty
+            end
 
-        clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", color.."("..branch..")")
-        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", "")
-        return true
+            clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", color.."("..branch..")")
+            return false
+        end
     end
 
     -- No mercurial present or not in mercurial file
@@ -86,18 +147,20 @@ function git_prompt_filter()
         dirty = "\x1b[31;1m",
     }
 
-    local branch = get_git_branch()
-    if branch then
-        -- Has branch => therefore it is a git folder, now figure out status
-        if get_git_status() then
-            color = colors.clean
-        else
-            color = colors.dirty
-        end
+    if get_git_dir() then
+        -- if we're inside of git repo then try to detect current branch
+        local branch = get_git_branch()
+        if branch then
+            -- Has branch => therefore it is a git folder, now figure out status
+            if get_git_status() then
+                color = colors.clean
+            else
+                color = colors.dirty
+            end
 
-        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")")
-        clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", "")
-        return true
+            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")")
+            return false
+        end
     end
 
     -- No git present or not in git file

--- a/config/cmder.lua
+++ b/config/cmder.lua
@@ -136,7 +136,7 @@ end
  -- @return {bool}
 ---
 function get_git_status()
-    return os.execute("git diff --quiet --ignore-submodules HEAD")
+    return os.execute("git diff --quiet --ignore-submodules HEAD 2>nul")
 end
 
 function git_prompt_filter()


### PR DESCRIPTION
This PR dramatically improves performance of promp filtering for git and mercurial by using custom logic to pre-check if process calls is necessary. The overal `clink.prompt_filter` execution time is decreased from ~600 ms to:
- ~10 ms in non-repo directory
- ~130 ms for git repos
- ~350 ms for hg repos