### PR TITLE
git and Posh-git check

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -14,13 +14,24 @@ try {
     $gitStatus = $false
 }
 
+function checkGit($Path) {
+    if (Test-Path -Path (Join-Path $Path '.git/') ) {
+        Write-VcsStatus
+        return
+    }
+    $SplitPath = split-path $path
+    if ($SplitPath) {
+        checkGit($SplitPath)
+    }
+}
+
 # Set up a Cmder prompt, adding the git prompt parts inside git repos
 function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
     $Host.UI.RawUI.ForegroundColor = "White"
     Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
-        Write-VcsStatus
     if($gitStatus){
+        checkGit($pwd.ProviderPath)
     }
     $global:LASTEXITCODE = $realLASTEXITCODE
     Write-Host "`nλ" -NoNewLine -ForegroundColor "DarkGray"

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -5,13 +5,22 @@ if( -not $env:PSModulePath.Contains($CmderModulePath) ){
     $env:PSModulePath = $env:PSModulePath.Insert(0, "$CmderModulePath;")
 }
 
+try {
+    Get-command -Name "git" -ErrorAction Stop >$null
+    Import-Module -Name "posh-git" -ErrorAction Stop >$null
+    $gitStatus = $true
+} catch {
+    Write-Warning "Missing git support"
+    $gitStatus = $false
+}
+
 # Set up a Cmder prompt, adding the git prompt parts inside git repos
 function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
     $Host.UI.RawUI.ForegroundColor = "White"
     Write-Host $pwd.ProviderPath -NoNewLine -ForegroundColor Green
-    if (Get-Module posh-git) {
         Write-VcsStatus
+    if($gitStatus){
     }
     $global:LASTEXITCODE = $realLASTEXITCODE
     Write-Host "`nλ" -NoNewLine -ForegroundColor "DarkGray"
@@ -19,7 +28,7 @@ function global:prompt {
 }
 
 # Load special features come from posh-git
-if (Get-Module posh-git) {
+if ($gitStatus) {
     Enable-GitColors
     Start-SshAgent -Quiet
 }


### PR DESCRIPTION
1. If the minimal client is used there's a chance git doesn't exist on the users machine.
1. Really look for the posh-git module. It seems to need importing because it doesn't have a module manifest. 

I didn't think this looked right so I added some work to it. Somewhere in the build we need to `install-module posh-git` and put it in the `vendor/` path. That will save us adding posh-git to the repo.

See the commit messages for more info I tried to be quite clear. 