### PR TITLE
Helper function using powershell to register the cmder context menu

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -65,3 +65,32 @@ function Cleanup-Git () {
     $gitdir = '/vendor/msysgit/libexec/git-core/'
     Get-Childitem $gitdir -Exclude git.exe | Where-Object{!($_.PSIsContainer)} | Foreach-Object { Remove-Item $_.FullName }
 }
+
+function Register-Cmder(){
+    [CmdletBinding()]
+    Param
+    (
+        # Text for the context menu item.
+        $MenuText = "Cmder Here"
+
+        , # Defaults to the current cmder directory when run from cmder.
+        $PathToExe = (Join-Path $env:CMDER_ROOT "cmder.exe")
+
+        , # Commands the context menu will execute.
+        $Command = "%V"
+
+        , # Defaults to the icons folder in the cmder package.
+        $icon = (Split-Path $PathToExe | join-path -ChildPath 'icons/cmder.ico')
+    )
+    Begin
+    {
+        New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT
+    }
+    Process
+    {
+        New-Item -Path "HKCR:\Directory\Shell\Cmder" -Force -Value $MenuText
+        New-ItemProperty -Path "HKCR:\Directory\Shell\Cmder" -Force -Name "Icon" -Value `"$icon`"
+        New-ItemProperty -Path "HKCR:\Directory\Shell\Cmder" -Force -Name "NoWorkingDirectory"
+        New-Item -Path "HKCR:\Directory\Shell\Cmder\Command" -Force -Value "`"$PathToExe`" `"$Command`" "
+    }
+}


### PR DESCRIPTION
I wanted to start work on just having a cmder powershell module for us to use to build the packages and also expose any settings we like through it. adding features to the `scripts/` bit to just town the whole folder into a module and move it to `vendor/`

A neat by product is that users can now re-run this command and set custom
icons.

Some problems;
- This function must be run as an administrator since we're touching the registry.
- I'm not sure what the `%V` command does but it's not opening in the targeted
folder as yet.
- The output is a little ugly at present.

Apparently my pull requests come in pairs.