### PR TITLE
Remove depreciated Enable-GitColors in posh-git

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -51,7 +51,6 @@ function global:prompt {
 
 # Load special features come from posh-git
 if ($gitStatus) {
-    Enable-GitColors
     Start-SshAgent -Quiet
 }
 


### PR DESCRIPTION
The function Enable-GitColors is depreciated in dahlbyk/posh-git@4e778e2480f584e039b47f0db1c020a197ee9e8f and should be removed here as well. Everytime the console runs, a depreciated warning is shown.