### PR TITLE
Check for a custom user shell init script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ vendor/*/*
 config/.history
 Thumbs.db
 *.exe
+*.dll
 build/
 Version v*

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -77,7 +77,7 @@
 			<value name="StartFarEditors" type="hex" data="00"/>
 			<value name="StoreTaskbarkTasks" type="hex" data="00"/>
 			<value name="StoreTaskbarCommands" type="hex" data="00"/>
-			<value name="CmdLineHistory" type="multi"><line data=";C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\"/></value>
+			<value name="CmdLineHistory" type="multi"></value>
 			<value name="SingleInstance" type="hex" data="00"/>
 			<value name="ShowHelpTooltips" type="hex" data="01"/>
 			<value name="Multi" type="hex" data="01"/>

--- a/launcher/CmderLauncher.sln
+++ b/launcher/CmderLauncher.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CmderLauncher", "CmderLauncher.vcxproj", "{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}"
 EndProject

--- a/launcher/CmderLauncher.vcxproj
+++ b/launcher/CmderLauncher.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -14,19 +14,18 @@
     <ProjectGuid>{4A8485A5-B7DD-4C44-B7F6-3E2765DD0CD3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CmderLauncher</RootNamespace>
-    <TargetPlatformVersion>8.1</TargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -60,4 +60,9 @@
     )
 )
 
+:: Call user-init script, if any
+@if defined CMDER_USER_INIT (
+  @if exist "%CMDER_USER_INIT%" call "%CMDER_USER_INIT%"
+)
+
 :: @call "%CMDER_ROOT%/bin/agent.cmd"

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -1,4 +1,9 @@
-﻿# Add Cmder modules directory to the autoload path.
+﻿# Compatibility with PS major versions <= 2
+if(!$PSScriptRoot) {
+    $PSScriptRoot = Split-Path $Script:MyInvocation.MyCommand.Path
+}
+
+# Add Cmder modules directory to the autoload path.
 $CmderModulePath = Join-path $PSScriptRoot "psmodules/"
 
 if( -not $env:PSModulePath.Contains($CmderModulePath) ){

--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -11,7 +11,13 @@ if( -not $env:PSModulePath.Contains($CmderModulePath) ){
 }
 
 try {
+    # Check if git is on PATH, i.e. Git already installed on system
     Get-command -Name "git" -ErrorAction Stop >$null
+} catch {
+    $env:Path += ";$env:CMDER_ROOT\vendor\msysgit\bin"
+}
+
+try {
     Import-Module -Name "posh-git" -ErrorAction Stop >$null
     $gitStatus = $true
 } catch {


### PR DESCRIPTION
Allow the user to further customer their shell environment without having to touch files in the vendor directory. 

After the usual setup in init.bat, check if there is a CMDER_USER_INIT variable defined. If found, call the bat file specified. 